### PR TITLE
Support IAM usernames which contain '.'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     unicode-display_width (2.2.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-linux
 

--- a/lib/aws_ec2_environment/ssm_port_forwarding_session.rb
+++ b/lib/aws_ec2_environment/ssm_port_forwarding_session.rb
@@ -121,7 +121,7 @@ class AwsEc2Environment
     end
 
     def wait_for_session_id
-      _, session_id = expect_cmd_output(/Starting session with SessionId: ([\w-]+)\r?\n/, @timeout) || []
+      _, session_id = expect_cmd_output(/Starting session with SessionId: ([=,.@\w-]+)\r?\n/, @timeout) || []
 
       if session_id.nil?
         fail(


### PR DESCRIPTION
I fixed this on the 2.7.5 branch but not `main`.