### PR TITLE
Add instruction to require the gem in Capfile before it can be used in capistrano deploy configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ the instance id with `#{id}`.
 ### With Capistrano
 
 ```ruby
-#./ Capfile
+# ./Capfile
 # ...
 require "aws_ec2_environment"
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ the instance id with `#{id}`.
 ### With Capistrano
 
 ```ruby
+#./ Capfile
+# ...
+require "aws_ec2_environment"
+
 # ./config/deploy/production.rb
 set :rails_env, "production"
 set :branch, "production"


### PR DESCRIPTION
This require can be anywhere, but Capfile means it'll be available in deploy.rb and also in each environments' .rb file.