### PR TITLE
fix: add general `Error` parent class

### DIFF
--- a/lib/aws_ec2_environment.rb
+++ b/lib/aws_ec2_environment.rb
@@ -2,16 +2,16 @@ require "aws-sdk-ec2"
 require "socket"
 require "yaml"
 
-require_relative "aws_ec2_environment/ssm_port_forwarding_session"
-require_relative "aws_ec2_environment/ci_service"
-require_relative "aws_ec2_environment/config"
-require_relative "aws_ec2_environment/version"
-
 class AwsEc2Environment
   class Error < StandardError; end
   class BastionNotExpectedError < Error; end
   class BastionNotFoundError < Error; end
   class EnvironmentConfigNotFound < Error; end
+
+  require_relative "aws_ec2_environment/ssm_port_forwarding_session"
+  require_relative "aws_ec2_environment/ci_service"
+  require_relative "aws_ec2_environment/config"
+  require_relative "aws_ec2_environment/version"
 
   attr_reader :config
 

--- a/lib/aws_ec2_environment.rb
+++ b/lib/aws_ec2_environment.rb
@@ -8,9 +8,10 @@ require_relative "aws_ec2_environment/config"
 require_relative "aws_ec2_environment/version"
 
 class AwsEc2Environment
-  class BastionNotExpectedError < StandardError; end
-  class BastionNotFoundError < StandardError; end
-  class EnvironmentConfigNotFound < StandardError; end
+  class Error < StandardError; end
+  class BastionNotExpectedError < Error; end
+  class BastionNotFoundError < Error; end
+  class EnvironmentConfigNotFound < Error; end
 
   attr_reader :config
 

--- a/lib/aws_ec2_environment/ssm_port_forwarding_session.rb
+++ b/lib/aws_ec2_environment/ssm_port_forwarding_session.rb
@@ -6,9 +6,9 @@ require "json"
 
 class AwsEc2Environment
   class SsmPortForwardingSession
-    class SessionIdNotFoundError < StandardError; end
-    class SessionTimedOutError < StandardError; end
-    class SessionProcessError < StandardError; end
+    class SessionIdNotFoundError < Error; end
+    class SessionTimedOutError < Error; end
+    class SessionProcessError < Error; end
 
     # @return [String]
     attr_reader :instance_id

--- a/sig/aws_ec2_environment.rbs
+++ b/sig/aws_ec2_environment.rbs
@@ -1,13 +1,16 @@
 class AwsEc2Environment
   VERSION: String
 
-  class BastionNotExpectedError < StandardError
+  class Error < StandardError
   end
 
-  class BastionNotFoundError < StandardError
+  class BastionNotExpectedError < Error
   end
 
-  class EnvironmentConfigNotFound < StandardError
+  class BastionNotFoundError < Error
+  end
+
+  class EnvironmentConfigNotFound < Error
   end
 
   attr_reader config: Config

--- a/sig/aws_ec2_environment/ssm_port_forwarding_session.rbs
+++ b/sig/aws_ec2_environment/ssm_port_forwarding_session.rbs
@@ -1,12 +1,12 @@
 class AwsEc2Environment
   class SsmPortForwardingSession
-    class SessionIdNotFoundError < StandardError
+    class SessionIdNotFoundError < Error
     end
 
-    class SessionTimedOutError < StandardError
+    class SessionTimedOutError < Error
     end
 
-    class SessionProcessError < StandardError
+    class SessionProcessError < Error
     end
 
     attr_reader instance_id: String


### PR DESCRIPTION
This makes it easy to catch all errors thrown by this gem without having to list them specifically.