### PR TITLE
ci: add new darwin 22 platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux


### PR DESCRIPTION
This is required for running against the latest version of macOS in CI