### PR TITLE
chore: add `arm64-darwin-23` platform to lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux
@@ -105,4 +106,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.3.17
+   2.5.7


### PR DESCRIPTION
Beep boop