### PR TITLE
fix: make sure string used for capturing cmd output is unfrozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- Make sure string used for capturing cmd output is unfrozen
+  ([#25](https://github.com/ackama/aws_ec2_environment/pull/25))
+
 ## [0.1.0] - 2022-08-17
 
 - Initial release

--- a/lib/aws_ec2_environment/ssm_port_forwarding_session.rb
+++ b/lib/aws_ec2_environment/ssm_port_forwarding_session.rb
@@ -34,7 +34,7 @@ class AwsEc2Environment
 
       @reader, @writer, @pid = PTY.spawn(ssm_port_forward_cmd(local_port, reason))
 
-      @cmd_output = ""
+      @cmd_output = +""
       @session_id = wait_for_session_id
 
       @logger.info("SSM session #{@session_id} opening, forwarding port #{remote_port} on #{instance_id}")


### PR DESCRIPTION
This ensures that we will work in a frozen-by-default world